### PR TITLE
Use the open_if_exists method from jinja2.utils

### DIFF
--- a/src/anytemplate/engines/jinja2.py
+++ b/src/anytemplate/engines/jinja2.py
@@ -46,7 +46,7 @@ def _load_file_itr(files, encoding):
     :param encoding: Encoding, e.g. 'utf-8'
     """
     for filename in files:
-        fileobj = jinja2.loaders.open_if_exists(filename)
+        fileobj = jinja2.utils.open_if_exists(filename)
         if fileobj is not None:
             try:
                 yield (fileobj.read().decode(encoding),


### PR DESCRIPTION
Replaces the library used to call open_if_exists, from jinja2.loaders, to jinja2.utils

Fixes an error found when running anytemplate in Python 3.12.